### PR TITLE
Some extra clean up, and removal of an added infinite loop

### DIFF
--- a/src/linked_list/mod.rs
+++ b/src/linked_list/mod.rs
@@ -28,22 +28,17 @@ impl<'a, T> LinkedList<'a, T> {
     }
 
     pub fn push_front(&mut self, node: &'a LinkedListNode<'a, T>) {
-        match self.head {
-            None => self.head = Some(node),
-            Some(head) => {
-                node.next.replace(Some(head));
-                self.head = Some(node);
-            }
-        };
+        if let Some(head) = self.head {
+            node.next.replace(Some(head));
+        }
+        self.head = Some(node);
     }
 
     pub fn push_back(&mut self, node: &'a LinkedListNode<'a, T>) {
         match self.head {
             None => self.head = Some(node),
-            Some(head) => {
-                let mut current = head;
-
-                while let Some(next) = head.next.get() {
+            Some(mut current) => {
+                while let Some(next) = current.next.get() {
                     current = next;
                 }
 
@@ -55,12 +50,9 @@ impl<'a, T> LinkedList<'a, T> {
     pub fn pop_front(&mut self) -> Option<&'a LinkedListNode<'a, T>> {
         let popped = self.head;
 
-        match self.head {
-            None => (),
-            Some(head) => {
-                self.head = head.next.get();
-            }
-        };
+        if let Some(head) = self.head {
+            self.head = head.next.get();
+        }
 
         popped
     }
@@ -69,21 +61,17 @@ impl<'a, T> LinkedList<'a, T> {
         match self.head {
             None => None,
             Some(head) => {
-                if let Some(head_next) = head.next.get() {
+                if let Some(mut current) = head.next.get() {
                     let mut previous = head;
-                    let mut current = head_next;
 
                     while let Some(next) = current.next.get() {
                         previous = current;
                         current = next;
                     }
 
-                    previous.next.replace(None);
-                    Some(current)
+                    previous.next.replace(None)
                 } else {
-                    let popped = self.head;
-                    self.head = None;
-                    popped
+                    self.head.take()
                 }
             }
         }

--- a/src/linked_list/test.rs
+++ b/src/linked_list/test.rs
@@ -23,12 +23,15 @@ fn should_push_back() {
     let mut list = LinkedList::new();
     let node1: LinkedListNode<u8> = LinkedListNode::new(21);
     let node2: LinkedListNode<u8> = LinkedListNode::new(42);
+    let node3: LinkedListNode<u8> = LinkedListNode::new(84);
 
     list.push_back(&node1);
     list.push_back(&node2);
+    list.push_back(&node3);
 
     assert_eq!(&21, list.pop_front().unwrap().value());
     assert_eq!(&42, list.pop_front().unwrap().value());
+    assert_eq!(&84, list.pop_front().unwrap().value());
     assert!(list.pop_front().is_none());
 }
 


### PR DESCRIPTION
I seem to have added an infinite loop that the tests didn't catch so I've fixed that, also I made a few more changes that take advantage of return types and pattern matching (even more `if let`s).

I also implemented `Iterator` in the `iter` branch, as an independent type and then implemented `IntoIterator`, as implementing `Iterator` directly would cause a conflict with `for_each`