### PR TITLE
Made a Callback macro and a few callback types to encapsulate the nifty find

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,9 +2,9 @@ name: Rust
 
 on:
   push:
-    branches: [ actions ]
+    branches: [ master ]
   pull_request:
-    branches: [ actions ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ actions ]
+  pull_request:
+    branches: [ actions ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/src/callback/mod.rs
+++ b/src/callback/mod.rs
@@ -11,7 +11,7 @@ macro_rules! make_callback {
 
         impl<'life, $($($Arg,)*)*$($Ret)*> $Name<'life, $($($Arg,)*)*$($Ret)*> {
             #[inline]
-            pub fn make<Context>(context: &'life Context, callback: fn(&Context, $($(&$Arg,)*)*) $(-> $Ret)*) -> Self {
+            pub fn new<Context>(context: &'life Context, callback: fn(&Context, $($(&$Arg,)*)*) $(-> $Ret)*) -> Self {
                 Self {
                     context: unsafe { ::core::intrinsics::transmute(context) },
                     callback: unsafe { ::core::intrinsics::transmute(callback) },

--- a/src/callback/mod.rs
+++ b/src/callback/mod.rs
@@ -1,0 +1,49 @@
+#[cfg(test)]
+mod test;
+
+macro_rules! make_callback {
+    ($Name:ident$([$($arg:ident: $Arg:ident),*])?$(,)? $(-> $Ret:ident)?) => {
+        pub struct $Name<'life, $($($Arg,)*)*$($Ret)*> {
+            context: *const (),
+            callback: fn(*const (), $($(&$Arg,)*)*) $(-> $Ret)*,
+            _life: ::core::marker::PhantomData<&'life ()>,
+        }
+
+        impl<'life, $($($Arg,)*)*$($Ret)*> $Name<'life, $($($Arg,)*)*$($Ret)*> {
+            #[inline]
+            pub fn make<Context>(context: &'life Context, callback: fn(&Context, $($(&$Arg,)*)*) $(-> $Ret)*) -> Self {
+                Self {
+                    context: unsafe { ::core::intrinsics::transmute(context) },
+                    callback: unsafe { ::core::intrinsics::transmute(callback) },
+                    _life: ::core::marker::PhantomData,
+                }
+            }
+
+            #[inline]
+            pub fn call(&self, $($($arg: &$Arg,)*)*) $(-> $Ret)* {
+                (self.callback)(self.context, $($($arg,)*)*)
+            }
+        }
+
+        impl<'life, $($($Arg,)*)*$($Ret)*> ::core::clone::Clone for $Name<'life, $($($Arg,)*)*$($Ret)*> {
+            #[inline]
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+
+        impl<'life, $($($Arg,)*)*$($Ret)*> ::core::marker::Copy for $Name<'life, $($($Arg,)*)*$($Ret)*> {}
+    };
+}
+
+make_callback!(Callback);
+make_callback!(CallbackWithReturn -> Ret);
+
+make_callback!(CallbackWith1Argument[a: Arg]);
+make_callback!(CallbackWith1ArgumentAndReturn[a: Arg] -> Ret);
+
+make_callback!(CallbackWith2Arguments[a: Arg1, b: Arg2]);
+make_callback!(CallbackWith2ArgumentsAndReturn[a: Arg1, b: Arg2] -> Ret);
+
+make_callback!(CallbackWith3Arguments[a: Arg1, b: Arg2, c: Arg3]);
+make_callback!(CallbackWith3ArgumentsAndReturn[a: Arg1, b: Arg2, c: Arg3] -> Ret);

--- a/src/callback/test.rs
+++ b/src/callback/test.rs
@@ -3,12 +3,12 @@ use super::*;
 #[test]
 fn can_make_cb() {
     let x = 42;
-    let _ = CallbackWithReturn::make(&x, |x| x + 1);
+    let _ = CallbackWithReturn::new(&x, |x| x + 1);
 }
 
 #[test]
 fn can_call_cb() {
     let x = 42;
-    let cb = CallbackWithReturn::make(&x, |x| x + 1);
+    let cb = CallbackWithReturn::new(&x, |x| x + 1);
     assert_eq!(cb.call(), 43);
 }

--- a/src/callback/test.rs
+++ b/src/callback/test.rs
@@ -1,0 +1,14 @@
+use super::*;
+
+#[test]
+fn can_make_cb() {
+    let x = 42;
+    let _ = CallbackWithReturn::make(&x, |x| x + 1);
+}
+
+#[test]
+fn can_call_cb() {
+    let x = 42;
+    let cb = CallbackWithReturn::make(&x, |x| x + 1);
+    assert_eq!(cb.call(), 42);
+}

--- a/src/callback/test.rs
+++ b/src/callback/test.rs
@@ -10,5 +10,5 @@ fn can_make_cb() {
 fn can_call_cb() {
     let x = 42;
     let cb = CallbackWithReturn::make(&x, |x| x + 1);
-    assert_eq!(cb.call(), 42);
+    assert_eq!(cb.call(), 43);
 }

--- a/src/event/mod.rs
+++ b/src/event/mod.rs
@@ -20,7 +20,7 @@ impl<'a, Arg> Event<'a, Arg> {
         context: &'a Context,
         f: fn(&Context, &Arg),
     ) -> EventSubscription<'a, Arg> {
-        EventSubscription::new(EventSubscriptionState::make(context, f))
+        EventSubscription::new(EventSubscriptionState::new(context, f))
     }
 
     pub fn subscribe(&mut self, subscription: &'a EventSubscription<'a, Arg>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
+pub mod callback;
 pub mod event;
 pub mod linked_list;
 pub mod timer;

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -46,7 +46,7 @@ impl<'a> TimerGroup<'a> {
         timer
             .value
             .callback
-            .replace(Some(Callback::make(context, callback)));
+            .replace(Some(Callback::new(context, callback)));
 
         self.timers.push_back(timer);
     }

--- a/src/timer/mod.rs
+++ b/src/timer/mod.rs
@@ -53,9 +53,11 @@ impl<'a> TimerGroup<'a> {
 
     pub fn run(&mut self) {
         for timer_data in self.timers.iter() {
-            if let Some(callback) = timer_data.callback.get() {
-                callback.call();
-            }
+            timer_data
+                .callback
+                .get()
+                .expect("Trying to call an empty Timer Callback")
+                .call();
         }
     }
 }


### PR DESCRIPTION
Added a phantom borrow to them so that they are extra safe :D
And also added GitHub actions, since my machine suddenly didn't want to run `cargo test` and I didn't feel like debugging that today.

I'm not 100% sure of the Clone impl, but as far as I know and understand, a function ptr should be copy-able no matter what params it is defined to take, though the compiler's `#[derive[Clone]` didn't agree with me, it could've been that that optimization was never written into it though...